### PR TITLE
Remove current implementation of SponsorLink for now

### DIFF
--- a/src/WebSocketChannel/WebSocketChannel.csproj
+++ b/src/WebSocketChannel/WebSocketChannel.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\CodeAnalysis\CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="None" />
+    <!--<ProjectReference Include="..\CodeAnalysis\CodeAnalysis.csproj" ReferenceOutputAssembly="false" OutputItemType="None" />-->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Now that SponsorLink is OSS and based on received feedback it will change in many ways moving forward, we'll for now remove the current implementation from the package to address the issues that were raised.

See https://github.com/devlooped/SponsorLink